### PR TITLE
Fix interop problem with Intel OpenCL SDK

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -1,11 +1,10 @@
-
 #ifndef WEBCL_COMMON_H_
 #define WEBCL_COMMON_H_
 
 #include <v8.h>
 #include <node.h>
 
-#include <CL/cl.hpp>
+#include <CL/cl.h>
 
 #define WEBCL_COND_RETURN_THROW(error) if (ret == error) return ThrowException(Exception::Error(String::New(#error)));
 


### PR DESCRIPTION
node-webcl does not compile against the Intel OpenCL SDK, because the file CL/cl.hpp is missing. Would it be possible to use the standard CL/cl.h?
